### PR TITLE
adapted gemspec and container.rb to support Rails 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org/'
 
 gem "builder", "~> 3.0"
 gem "rubyzip", "~> 0.9.1"
-gem "activesupport", "~> 3.0"
+gem "activesupport", ">= 3.0"
 gem "hpricot", "~> 0.8.6"
 gem "rspec", "~> 2.9"
 gem "rspec_hpricot_matchers" , "~> 1.0"

--- a/lib/odf/container.rb
+++ b/lib/odf/container.rb
@@ -16,7 +16,7 @@
 # along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'rubygems'
-gem 'activesupport', '~> 3.0'
+gem 'activesupport', '>= 3.0'
 
 require 'active_support/inflector'
 

--- a/rodf.gemspec
+++ b/rodf.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rodf"
-  s.version = "0.3.4"
+  s.version = "0.3.5pre"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Thiago Arrais, Foivos Zakkak"]
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<builder>, ["~> 3.0"])
       s.add_runtime_dependency(%q<rubyzip>, ["~> 0.9.1"])
-      s.add_runtime_dependency(%q<activesupport>, ["~> 3.0"])
+      s.add_runtime_dependency(%q<activesupport>, [">= 3.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.9"])
       s.add_development_dependency(%q<rspec_hpricot_matchers>, ["~> 1.0"])
       s.add_development_dependency(%q<echoe>, ["~> 4.6"])
     else
       s.add_dependency(%q<builder>, ["~> 3.0"])
       s.add_dependency(%q<rubyzip>, ["~> 0.9.1"])
-      s.add_dependency(%q<activesupport>, ["~> 3.0"])
+      s.add_dependency(%q<activesupport>, [">= 3.0"])
       s.add_dependency(%q<rspec>, ["~> 2.9"])
       s.add_dependency(%q<rspec_hpricot_matchers>, ["~> 1.0"])
       s.add_dependency(%q<echoe>, ["~> 4.6"])
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<builder>, ["~> 3.0"])
     s.add_dependency(%q<rubyzip>, ["~> 0.9.1"])
-    s.add_dependency(%q<activesupport>, ["~> 3.0"])
+    s.add_dependency(%q<activesupport>, [">= 3.0"])
     s.add_dependency(%q<rspec>, ["~> 2.9"])
     s.add_dependency(%q<rspec_hpricot_matchers>, ["~> 1.0"])
     s.add_dependency(%q<echoe>, ["~> 4.6"])


### PR DESCRIPTION
Adapted the gem to work in Rails >= 3.0 instead of ~> 3.0 so it supports Rails 4.

Works without any code modification when moving from Rails 3 to Rails 4 in my web application.
