### PR TITLE
rubyzip "~>0.9.1" -> "~> 1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org/'
 
 gem "builder", "~> 3.0"
-gem "rubyzip", "~> 0.9.1"
+gem "rubyzip", "~> 1.0"
 gem "activesupport", "~> 3.0"
 gem "hpricot", "~> 0.8.6"
 gem "rspec", "~> 2.9"

--- a/lib/odf/document.rb
+++ b/lib/odf/document.rb
@@ -17,7 +17,7 @@
 
 require 'rubygems'
 
-require 'zip/zip'
+require 'zip'
 
 require 'odf/container'
 require 'odf/skeleton'
@@ -33,7 +33,7 @@ module ODF
     end
 
     def write_to(ods_file_name)
-      ods_file = Zip::ZipFile.open(ods_file_name, Zip::ZipFile::CREATE)
+      ods_file = Zip::File.open(ods_file_name, Zip::File::CREATE)
       ods_file.get_output_stream('META-INF/manifest.xml') {|f| f << self.class.skeleton.manifest(self.class.doc_type) }
 
       ods_file.get_output_stream('styles.xml') do |f|

--- a/rodf.gemspec
+++ b/rodf.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rodf"
-  s.version = "0.3.4"
+  s.version = "0.3.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Thiago Arrais, Foivos Zakkak"]
@@ -23,14 +23,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<builder>, ["~> 3.0"])
-      s.add_runtime_dependency(%q<rubyzip>, ["~> 0.9.1"])
+      s.add_runtime_dependency(%q<rubyzip>, ["~> 1.0"])
       s.add_runtime_dependency(%q<activesupport>, ["~> 3.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.9"])
       s.add_development_dependency(%q<rspec_hpricot_matchers>, ["~> 1.0"])
       s.add_development_dependency(%q<echoe>, ["~> 4.6"])
     else
       s.add_dependency(%q<builder>, ["~> 3.0"])
-      s.add_dependency(%q<rubyzip>, ["~> 0.9.1"])
+      s.add_dependency(%q<rubyzip>, ["~> 1.0"])
       s.add_dependency(%q<activesupport>, ["~> 3.0"])
       s.add_dependency(%q<rspec>, ["~> 2.9"])
       s.add_dependency(%q<rspec_hpricot_matchers>, ["~> 1.0"])
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<builder>, ["~> 3.0"])
-    s.add_dependency(%q<rubyzip>, ["~> 0.9.1"])
+    s.add_dependency(%q<rubyzip>, ["~> 1.0"])
     s.add_dependency(%q<activesupport>, ["~> 3.0"])
     s.add_dependency(%q<rspec>, ["~> 2.9"])
     s.add_dependency(%q<rspec_hpricot_matchers>, ["~> 1.0"])


### PR DESCRIPTION
With the changes from this merge request, rodf works with rubyzip 1.0

Motivation: My tests broke with the latest Firefox version (26), to make them work again I need to upgrade the selenium-webdriver gem to version 2.39.0 which requires rubyzip "~> 1.0"

All the specs are passing.
