### PR TITLE
Allow Options in ODF::Table's row method for adding Row Styles

### DIFF
--- a/lib/odf/table.rb
+++ b/lib/odf/table.rb
@@ -32,8 +32,8 @@ module ODF
     end
 
     alias create_row row
-    def row(&contents)
-      create_row(next_row) {instance_eval(&contents) if block_given?}
+    def row(options={}, &contents)
+      create_row(next_row, options) {instance_eval(&contents) if block_given?}
     end
 
     def xml

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -74,4 +74,17 @@ describe ODF::Table do
     output.should have_tag('//table:table-row')
     output.should have_tag('//table:table-cell')
   end
+
+  it "should have allow row styles" do
+    output = ODF::Table.create('MyTable') do
+      row style: :bold do
+        cell
+      end
+      row style: :underline do
+        cell
+      end
+    end
+    output.should include('table:table-row table:style-name="bold"')
+    output.should include('table:table-row table:style-name="underline"')
+  end
 end


### PR DESCRIPTION
The ODF::Row class initialize allows an options hash for applying a style. The ODF::Table class has a `row` method that initializes these rows as well. I added the ability to include the options hash in ODF::Table's `row` method.