### PR TITLE
Respect line breaks within cell

### DIFF
--- a/lib/rodf/cell.rb
+++ b/lib/rodf/cell.rb
@@ -130,11 +130,15 @@ module RODF
     def make_value_paragraph
       if contains_string?
         cell, value, url = self, @value, @url
-        paragraph do
-          if cell.contains_url?
-            link value, href: url
-          else
-            self << value
+
+        # Split out newlines to be new cells since the text has been escaped at this point
+        value.to_s.split("\n").each do |split_value|
+          paragraph do
+            if cell.contains_url?
+              link split_value, href: url
+            else
+              self << split_value
+            end
           end
         end
       end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -113,6 +113,17 @@ describe RODF::Cell do
     cell.xml.should_not have_tag('text:a')
   end
 
+  it "should respect newlines and split across multiple text:p cells" do
+    c = RODF::Cell.new("testing1\ntesting2")
+    output = c.xml
+
+    output.should have_tag("//text:p", count: 2)
+
+    ps = Hpricot(output).search('text:p')
+    ps[0].innerHTML.should == 'testing1'
+    ps[1].innerHTML.should == 'testing2'
+  end
+
   ### FLOAT
   it "should allow value types to be specified" do
     output = RODF::Cell.new(34.2, type: :float).xml


### PR DESCRIPTION
In reference to issue #22 

Adding logic to split out lines which include an explicit newline (within double quotes, as Ruby dictates) for a new cell out across multiple paragraphs.

Closes #22 