### PR TITLE
Ensure bytes method doesnt generate corrupt files with rubyzip 3.0 and above

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         include:
           ### TEST ALL RUBY VERSIONS
-          - ruby: "2.6"
-          - ruby: "2.7"
           - ruby: "3.0"
           - ruby: "3.1"
           - ruby: "3.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 ## Unreleased - [View Diff](https://github.com/westonganger/rodf/compare/v1.2.0..master)
-- Nothing yet
+- [#49](https://github.com/westonganger/rodf/pull/49) - Ensure `bytes` method doesnt use zip64 which started happening with rubyzip >= 3.0
+- Require rubyzip >= 3.2 which requires Ruby 3.0+
 
 ## v1.2.0 - [View Diff](https://github.com/westonganger/rodf/compare/v1.1.1..v1.2.0)
 - Allow passing `:style` argument to `Span`
@@ -67,7 +68,7 @@
 ## v0.1.3
 - Dependency fix (by Merul Patel)
 
-## v0.1.2 
+## v0.1.2
 - Cell span
 
 ## v0.1.1

--- a/lib/rodf/document.rb
+++ b/lib/rodf/document.rb
@@ -17,7 +17,7 @@ module RODF
     end
 
     def bytes
-      buffer = Zip::OutputStream::write_buffer do |zio|
+      buffer = Zip::OutputStream::write_buffer(suppress_extra_fields: [:zip64]) do |zio|
         zio.put_next_entry('META-INF/manifest.xml')
 
         zio << self.class.skeleton.manifest(self.class.doc_type)

--- a/rodf.gemspec
+++ b/rodf.gemspec
@@ -11,14 +11,14 @@ Gem::Specification.new do |s|
   s.authors = ['Weston Ganger', 'Thiago Arrais']
   s.email = ["weston@westonganger.com", "thiago.arrais@gmail.com"]
   s.license = "MIT"
-  
+
   s.files = Dir.glob("{lib/**/*}") + %w{ LICENSE README.md Rakefile CHANGELOG.md }
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'builder', '>= 3.0'
-  s.add_runtime_dependency 'rubyzip', '>= 1.0'
+  s.add_runtime_dependency 'rubyzip', '>= 3.2'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
- Ensure `bytes` method doesnt use zip64 which started happening with rubyzip >= 3.0
- Require rubyzip >= 3.2